### PR TITLE
Add token support, tweak config, and improve startup reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 discover/node_modules
 reset.sh
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,13 @@ ENV ALERTMANAGER_VERSION 0.2.0
 # arch
 ENV DIST_ARCH linux-amd64
 
+# User config
+COPY .env /.env
+
 # Target discovery configs
-ENV RESIN_EMAIL yourResinEmail
-ENV RESIN_PASS yourResinPassword
-ENV RESIN_APP_NAME yourAppName
 ENV DISCOVERY_INTERVAL 30000
 
 # Alert Manager configs
-ENV GMAIL_ACCOUNT yourGmail
-ENV GMAIL_AUTH_TOKEN youGmailpassword
 ENV THRESHOLD_CPU 50
 ENV THRESHOLD_FS 50
 ENV THRESHOLD_MEM 500

--- a/README.md
+++ b/README.md
@@ -2,18 +2,22 @@ More info can be found on the [resin-blog](https://resin.io/blog/prometheusv2/)
 
 ### Required Environment variables
 
-| Key                | Description                           |
-|--------------------|---------------------------------------|
-| GMAIL_ACCOUNT     | Your Gmail email                      |
-| GMAIL_AUTH_TOKEN | Your Gmail password or auth token      |
-| RESIN_EMAIL       | Your resin.io email                   |
-| RESIN_PASS        | Your resin.io password                |
-| RESIN_APP_NAME   | Resin application you wish to monitor |
+| Key                | Description                                   |
+|--------------------|-----------------------------------------------|
+| GMAIL_ACCOUNT      | Your Gmail email                              |
+| GMAIL_AUTH_TOKEN   | Your Gmail password or auth token             |
+| RESIN_TOKEN        | Your resin.io token                           |
+| RESIN_EMAIL        | Your resin.io email, if not using a token     |
+| RESIN_PASS         | Your resin.io password, if not using a token  |
+| RESIN_APP_NAME     | Resin application name you wish to monitor    |
+
+These can be set in the Dockerfile, passed to Docker with `--env` at runtime, or placed in the `.env` in the root of this project in
+as `source`-able bash commands (`export RESIN_TOKEN=...`, newline separated)
 
 ### To run
 
 1. ```git clone git@github.com:resin-io-projects/resin-prometheus-server.git```
-2. Add required environment variables in `Dockerfile` or at runtime. 
+2. Add required environment variables in `Dockerfile`, at runtime with `--env`, or in a `.env` in `export A=B` format.
 3. Optional: If you'd like persistent grafana storage run: `docker run -d -v /var/lib/grafana --name grafana-storage busybox:latest`
 3. ```docker build -t prometheus .```
 4. ```docker run -t -i -p 80:80 -p 3000:3000 --name resinMonitor prometheus```

--- a/config/config.sh
+++ b/config/config.sh
@@ -1,3 +1,8 @@
+if [ -f /.env ]; then
+  echo 'Reading config from .env'
+  source /.env
+fi
+
 #replace vars in all config file types
 echo 'LOADING CONFIGS'
 find /etc/config -type f -exec sed -i -e s/GMAIL_ACCOUNT/${GMAIL_ACCOUNT}/g \

--- a/discovery/index.js
+++ b/discovery/index.js
@@ -4,13 +4,11 @@ var resin = require("resin-sdk")
 var fs = require("fs")
 var _ = require("lodash")
 
-credentials = { email: process.env.RESIN_EMAIL, password: process.env.RESIN_PASS };
+var login = process.env.RESIN_TOKEN ?
+  resin.auth.loginWithToken(process.env.RESIN_TOKEN) :
+  resin.auth.login({ email: process.env.RESIN_EMAIL, password: process.env.RESIN_PASS });
 
-resin.auth.login(credentials, function(error) {
-  if (error != null) {
-    throw error;
-  }
-
+login.then(function () {
   console.log("Successfully authenticated with resin API")
   setInterval(function(){
     resin.models.device.getAllByApplication(process.env.RESIN_APP_NAME).then(function(devices) {

--- a/discovery/index.js
+++ b/discovery/index.js
@@ -1,4 +1,4 @@
-console.log('discovery started')
+console.log('Discovery started')
 
 var resin = require("resin-sdk")
 var fs = require("fs")
@@ -10,14 +10,20 @@ var login = process.env.RESIN_TOKEN ?
 
 login.then(function () {
   console.log("Successfully authenticated with resin API")
-  setInterval(function(){
-    resin.models.device.getAllByApplication(process.env.RESIN_APP_NAME).then(function(devices) {
-      if (error) throw error;
-      // format array and save it as json file
-      saveJson(_.map(devices, format));
-    });
-  }, process.env.DISCOVERY_INTERVAL);
-});
+
+  updateTargetDevices();
+  setInterval(updateTargetDevices, process.env.DISCOVERY_INTERVAL);
+}).catch(console.error);
+
+function updateTargetDevices() {
+  resin.models.device.getAllByApplication(process.env.RESIN_APP_NAME)
+  .then(function(devices) {
+    console.log('Found', devices.length, 'target devices');
+
+    // format array and save it as json file
+    saveJson(_.map(devices, format));
+  }).catch(console.error);
+}
 
 function saveJson(array) {
   fs.writeFile(__dirname + '/targets.json', JSON.stringify(array), 'utf8')

--- a/start.sh
+++ b/start.sh
@@ -4,16 +4,22 @@ if [ -f /.env ]; then
 fi
 
 # Start prometheus server
-service grafana-server start &&
-# Add datasource to grafana
-curl 'http://admin:admin@127.0.0.1:3000/api/datasources' -X POST -H 'Content-Type: application/json;charset=UTF-8' --data-binary '{"name":"Prometheus","type":"prometheus","url":"http://localhost:80","access":"proxy","isDefault":true}'
+service grafana-server start
+
 # start node discover mechanism
-node /etc/prometheus-$PROMETHEUS_VERSION.$DIST_ARCH/discovery/index.js & \
+node /etc/prometheus-$PROMETHEUS_VERSION.$DIST_ARCH/discovery/index.js &
+sleep 5
+
 # start prometheus
-cd /etc/prometheus-$PROMETHEUS_VERSION.$DIST_ARCH \
-  && ./prometheus -web.listen-address ":80" \
+cd /etc/prometheus-$PROMETHEUS_VERSION.$DIST_ARCH
+./prometheus -web.listen-address ":80" \
   -storage.local.path "/data" -storage.local.retention ${STORAGE_LOCAL_RETENTION} \
   -alertmanager.url "http://localhost:9093" &
+sleep 1
+
+# Add datasource to grafana
+curl 'http://admin:admin@127.0.0.1:3000/api/datasources' -X POST -H 'Content-Type: application/json;charset=UTF-8' --data-binary '{"name":"Prometheus","type":"prometheus","url":"http://localhost:80","access":"proxy","isDefault":true}'
+
 # start alertmanager
-cd /etc/alertmanager-$ALERTMANAGER_VERSION.$DIST_ARCH \
-  && ./alertmanager -config.file=alertmanager.yml
+cd /etc/alertmanager-$ALERTMANAGER_VERSION.$DIST_ARCH
+./alertmanager -config.file=alertmanager.yml

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,8 @@
+if [ -f /.env ]; then
+  echo 'Reading config from .env'
+  source /.env
+fi
+
 # Start prometheus server
 service grafana-server start &&
 # Add datasource to grafana


### PR DESCRIPTION
This PR (based on my TTN talk setup):
* Encourages users to use a (gitignored) .env file to define config parameters, rather than having to commit their resin & gmail credentials into the dockerfile directly
* Adds support for using a resin token for authentication, not just a username/password
* Makes startup more reliable, by triggering device discovery immediately (not only after 30s), and waiting until Grafana & Prometheus are ready before registering them as the prometheus data source (right now, it's a race, which often fails)
* Simplifies and clarifies various small things

I've added you two as reviewers since I think you're now officially the maintainers of this, but feel free to ping whoever else might be relevant.